### PR TITLE
feat: Add query filter on eta tax subtype

### DIFF
--- a/erpnext_egypt_compliance/erpnext_eta/public/js/sales_invoice.js
+++ b/erpnext_egypt_compliance/erpnext_eta/public/js/sales_invoice.js
@@ -1,5 +1,6 @@
 frappe.ui.form.on('Sales Invoice', {
 	onload(frm) {
+		frm.trigger('set_query_for_eta_sub_type');
 		let eta_wrapper = $('.title-area').append('<div id="eta-status"></div>')
 
 		// your code here
@@ -13,6 +14,17 @@ frappe.ui.form.on('Sales Invoice', {
 		
 	},
 	refresh(frm) {
+	},
+	set_query_for_eta_sub_type(frm) { 
+		frm.set_query("eta_tax_sub_type", "taxes", function (doc, cdt, cdn) {
+			row = locals[cdt][cdn];
+			return {
+				filters: {
+					parent_eta_tax_type: row.eta_tax_type,
+					is_group: 0
+				},
+			};
+		});
 	},
 	eta_add_download_button(frm) {
 		frm.add_custom_button('Download ETA Json', () => {

--- a/erpnext_egypt_compliance/erpnext_eta/public/js/sales_taxes_and_charges_template.js
+++ b/erpnext_egypt_compliance/erpnext_eta/public/js/sales_taxes_and_charges_template.js
@@ -1,0 +1,19 @@
+frappe.ui.form.on("Sales Taxes and Charges Template", {
+	onload(frm) {
+		frm.trigger("set_query_for_eta_sub_type");
+	},
+	refresh(frm) {
+		// write your code here
+	},
+	set_query_for_eta_sub_type(frm) {
+		frm.set_query("eta_tax_sub_type", "taxes", function (doc, cdt, cdn) {
+			row = locals[cdt][cdn];
+			return {
+				filters: {
+					parent_eta_tax_type: row.eta_tax_type,
+					is_group: 0
+				},
+			};
+		});
+	},
+})

--- a/erpnext_egypt_compliance/hooks.py
+++ b/erpnext_egypt_compliance/hooks.py
@@ -14,6 +14,7 @@ doctype_js = {
     "Sales Invoice": "erpnext_eta/public/js/sales_invoice.js",
     "POS Invoice": "erpnext_eta/public/js/pos_invoice.js",
     "Item": "erpnext_eta/public/js/item.js",
+	"Sales Taxes and Charges Template": "erpnext_eta/public/js/sales_taxes_and_charges_template.js",
 }
 
 doc_events = {


### PR DESCRIPTION
Apply a **query filter** on the **ETA Tax Subtype** field in both the **Sales Invoice** and **Sales Taxes and Charges Template** DocTypes. The filter should be based on the selected **ETA Tax Type**, to prevent users from choosing a subtype that is not related to the selected tax type.

