### PR TITLE
fix: prevent crash and invalid governate when building ETA receiver address

### DIFF
--- a/erpnext_egypt_compliance/erpnext_eta/einvoice_schema.py
+++ b/erpnext_egypt_compliance/erpnext_eta/einvoice_schema.py
@@ -481,24 +481,6 @@ def get_receiver():
             title=_("ETA Validation"),
         )
 
-    eta_receiver = Receiver(
-        type=customer_type,
-        id=customer.get("tax_id"),
-        name=customer.get("customer_name"),
-        address=ReceiverAddress(
-            country="EG",
-            governate="Egypt",
-            regionCity="EG City",
-            street="Street 1",
-            buildingNumber="B0",
-            # postalCode=POS_INVOICE_RAW_DATA.get("postal_code"),
-            # floor=POS_INVOICE_RAW_DATA.get("floor"),
-            # room=POS_INVOICE_RAW_DATA.get("room"),
-            # landmark=POS_INVOICE_RAW_DATA.get("landmark"),
-            # additionalInformation=POS_INVOICE_RAW_DATA.get("additional_information"),
-        )
-    )
-    
     customer_address_name = customer.get("customer_primary_address")
     if customer_type == "F" and not customer_address_name:
         frappe.throw(
@@ -506,14 +488,30 @@ def get_receiver():
             title=_("ETA Validation"),
         )
 
+    # ETA requires every address field to be a non-empty string. Customers without a
+    # primary address - or with an incomplete one - fall back to these placeholders.
+    address = ReceiverAddress(
+        country="EG",
+        governate="Egypt",
+        regionCity="EG City",
+        street="Street 1",
+        buildingNumber="B0",
+        # postalCode=POS_INVOICE_RAW_DATA.get("postal_code"),
+        # floor=POS_INVOICE_RAW_DATA.get("floor"),
+        # room=POS_INVOICE_RAW_DATA.get("room"),
+        # landmark=POS_INVOICE_RAW_DATA.get("landmark"),
+        # additionalInformation=POS_INVOICE_RAW_DATA.get("additional_information"),
+    )
+
     if customer_address_name:
         customer_address = frappe.get_doc("Address", customer_address_name)
+        country_code = frappe.db.get_value("Country", customer_address.country, "code") if customer_address.country else None
         address = ReceiverAddress(
-            country=frappe.db.get_value("Country", customer_address.country, "code"),
-            governate=customer_address.state,
-            regionCity=customer_address.city,
-            street=customer_address.address_line1,
-            buildingNumber=customer_address.building_number or "B0"
+            country=(country_code or address.country).upper(),
+            governate=customer_address.state or customer_address.city or address.governate,
+            regionCity=customer_address.city or customer_address.state or address.regionCity,
+            street=customer_address.address_line1 or customer_address.address_line2 or address.street,
+            buildingNumber=customer_address.get("building_number") or address.buildingNumber,
             # postalCode=customer_address.pincode or None,
             # floor=customer_address.floor or None,
             # room=customer_address.room or None,

--- a/tests/test_envoice_schema.py
+++ b/tests/test_envoice_schema.py
@@ -6,13 +6,25 @@ from erpnext_egypt_compliance.erpnext_eta.utils import eta_round
 import erpnext_egypt_compliance.erpnext_eta.einvoice_schema as einvoice_schema
 from erpnext_egypt_compliance.erpnext_eta.einvoice_schema import (
     Discount,
+    ReceiverAddress,
     _get_item_code_and_type,
     _get_item_unit_value,
     _get_sales_and_net_totals,
     _resolve_show_discount,
     get_net_total_amount,
+    get_receiver,
     Value,
 )
+
+
+class _FakeDoc(dict):
+    """Minimal stand-in for a frappe Document: supports both attribute and dict-style access."""
+
+    def __getattr__(self, name):
+        return self.get(name)
+
+    def as_dict(self):
+        return dict(self)
 
 
 def test_eta_round(db_transaction):
@@ -275,3 +287,75 @@ def test_resolve_show_discount(monkeypatch, company_flag, price_list_flag, selli
     monkeypatch.setattr(frappe, "get_value", lambda *args, **kwargs: price_list_flag)
     company_data = {"show_discount_on_tax_invoice": company_flag}
     assert _resolve_show_discount(company_data, selling_price_list) is expected
+
+
+def _mock_customer(**overrides):
+    customer = {
+        "name": "Cust A",
+        "customer_name": "Cust A",
+        "eta_receiver_type": "B",
+        "tax_id": "123456789",
+        "customer_primary_address": None,
+    }
+    customer.update(overrides)
+    return customer
+
+
+def test_get_receiver_without_primary_address_uses_placeholder(monkeypatch):
+    """Customer with no primary address must not crash — falls back to the placeholder address."""
+    monkeypatch.setattr(einvoice_schema, "INVOICE_RAW_DATA", {"customer": "Cust A"})
+    monkeypatch.setattr(frappe, "get_doc", lambda doctype, name=None: _FakeDoc(_mock_customer()))
+
+    receiver = get_receiver()
+
+    assert receiver.address == ReceiverAddress(
+        country="EG", governate="Egypt", regionCity="EG City", street="Street 1", buildingNumber="B0"
+    )
+
+
+def test_get_receiver_falls_back_to_city_when_state_missing(monkeypatch):
+    """governate/regionCity must never be None even when the Address doctype's state is blank."""
+    monkeypatch.setattr(einvoice_schema, "INVOICE_RAW_DATA", {"customer": "Cust A"})
+
+    def _fake_get_doc(doctype, name=None):
+        if doctype == "Customer":
+            return _FakeDoc(_mock_customer(customer_primary_address="Addr-1"))
+        return _FakeDoc(
+            {"country": "Egypt", "state": None, "city": "giza", "address_line1": "Street X", "building_number": None}
+        )
+
+    monkeypatch.setattr(frappe, "get_doc", _fake_get_doc)
+    monkeypatch.setattr(frappe.db, "get_value", lambda *args, **kwargs: "eg")
+
+    receiver = get_receiver()
+
+    assert receiver.address == ReceiverAddress(
+        country="EG", governate="giza", regionCity="giza", street="Street X", buildingNumber="B0"
+    )
+
+
+def test_get_receiver_uses_complete_customer_address(monkeypatch):
+    """A fully populated Address is passed through as-is (country code uppercased)."""
+    monkeypatch.setattr(einvoice_schema, "INVOICE_RAW_DATA", {"customer": "Cust A"})
+
+    def _fake_get_doc(doctype, name=None):
+        if doctype == "Customer":
+            return _FakeDoc(_mock_customer(customer_primary_address="Addr-1"))
+        return _FakeDoc(
+            {
+                "country": "Egypt",
+                "state": "Giza",
+                "city": "6th of October",
+                "address_line1": "Industrial Zone",
+                "building_number": "12",
+            }
+        )
+
+    monkeypatch.setattr(frappe, "get_doc", _fake_get_doc)
+    monkeypatch.setattr(frappe.db, "get_value", lambda *args, **kwargs: "eg")
+
+    receiver = get_receiver()
+
+    assert receiver.address == ReceiverAddress(
+        country="EG", governate="Giza", regionCity="6th of October", street="Industrial Zone", buildingNumber="12"
+    )


### PR DESCRIPTION
## Summary
- `get_receiver()` built a placeholder `ReceiverAddress`, assigned it to a `Receiver` that was immediately discarded, and only defined the real `address` variable inside the `if customer_address_name:` branch. Customers without a primary address hit `UnboundLocalError: cannot access local variable 'address'` on submit.
- Once an address was added, fields were passed straight from the Address doctype (`state`, `city`, `address_line1`), which can be `None`. `ReceiverAddress` requires non-empty strings, so ETA validation failed with `governate: Input should be a valid string` whenever `state` was blank.

## Changes
- The placeholder address is now the fallback assigned to `address` up front, so customers without a primary address get a valid (placeholder) receiver instead of crashing.
- Each field from the customer's address falls back to a sensible alternate before the placeholder: `governate` → state, else city; `regionCity` → city, else state; `street` → address_line1, else address_line2; `buildingNumber` → placeholder if blank.
- Country code is uppercased to match ETA's expected format (`eg` → `EG`).
- Removed the dead first `Receiver(...)` construction.

## Test plan
- [x] Verified against a live invoice whose customer address had `state=None` — no longer raises, `governate` falls back to `city`.
- [x] Verified a customer with no `customer_primary_address` at all — returns placeholder address instead of raising `UnboundLocalError`.
- [x] Verified a customer with a complete address — unchanged output.