### PR TITLE
fix: correct frappe.msgprint argument order in EInvoiceSubmitter

### DIFF
--- a/erpnext_egypt_compliance/erpnext_eta/einvoice_submitter.py
+++ b/erpnext_egypt_compliance/erpnext_eta/einvoice_submitter.py
@@ -21,7 +21,7 @@ class EInvoiceSubmitter:
 
         except Exception as e:
             self._handle_exception(e)
-            frappe.msgprint(alert=True, message="An error occurred while submitting the e-invoice.", indicator="red")
+            frappe.msgprint("An error occurred while submitting the e-invoice.", alert=True, indicator="red")
             return {"error": str(e)}
     
     def _prepare_data(self, einvoices):


### PR DESCRIPTION
## Summary
- `frappe.msgprint` was called with `alert=True, message="...", indicator="red"` — the message was passed as a keyword only, ahead of it positionally. This works but is inconsistent with the rest of the codebase and reads like a mistake at a glance.

## Changes
- Pass `message` as the first positional argument, matching the conventional call signature used elsewhere in this app.

## Test plan
- [x] No behavior change — same message/alert/indicator values, just argument order.